### PR TITLE
Add "modify" option to add, remove and replace attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,15 @@ connection.add(distinguishedName: "CN=judy,CN=User,DC=perfect,DC=com", attribute
 Function `LDAP.modify()` can modify attributes from a specific DN with parameters below:
 - distinguishedName: String, specific DN
 - attributes:[String:[String]], attributes as an dictionary to modify. In this dictionary, every attribute, as a unique key in the dictionary, could have a series of values as an array.
+- method: specify if an attribute should be added, removed or replaced (default)
+  - add: LDAP_MOD_ADD | LDAP_MOD_BVALUES
+  - remove: LDAP_MOD_DELETE | LDAP_MOD_BVALUES
+  - replace: LDAP_MOD_REPLACE | LDAP_MOD_BVALUES
 
 Both asynchronous modify() and synchronous modify() share the same parameters above, take example:
 
 ``` swift
-// try an modify() synchronously.
+// try and modify() synchronously.
 do {
   try connection.modify(distinguishedName: "CN=judy,CN=User,DC=perfect,DC=com", attributes: ["codePage":["437"]])
 }catch (let err) {
@@ -251,6 +255,24 @@ do {
 // try and modify() asynchronously:
 connection.modify(distinguishedName: "CN=judy,CN=User,DC=perfect,DC=com", attributes:["codePage":["437"]]) { err in
   // if nothing wrong, err will be nil
+}
+```
+
+Example: Add and remove user from group
+
+``` swift
+// add user to group
+do {
+  try connection.modify(distinguishedName: "CN=employee_group,CN=Group,DC=perfect,DC=com", attributes: ["member":["CN=judy,CN=User,DC=perfect,DC=com"]], method: LDAP_MOD_ADD | LDAP_MOD_BVALUES)
+}catch (let err) {
+    // failed for some reason
+}
+
+// remove user from group
+do {
+  try connection.modify(distinguishedName: "CN=employee_group,CN=Group,DC=perfect,DC=com", attributes: ["member":["CN=judy,CN=User,DC=perfect,DC=com"]], method: LDAP_MOD_DELETE | LDAP_MOD_BVALUES)
+}catch (let err) {
+    // failed for some reason
 }
 ```
 

--- a/Sources/PerfectLDAP/PerfectLDAP.swift
+++ b/Sources/PerfectLDAP/PerfectLDAP.swift
@@ -800,7 +800,7 @@ public class LDAP {
     threading.async {
       do {
         // perform adding
-        try self.modify(distinguishedName: distinguishedName, attributes: attributes, method)
+        try self.modify(distinguishedName: distinguishedName, attributes: attributes, method: method)
 
         // if nothing wrong, callback
         completion(nil)

--- a/Sources/PerfectLDAP/PerfectLDAP.swift
+++ b/Sources/PerfectLDAP/PerfectLDAP.swift
@@ -757,16 +757,20 @@ public class LDAP {
   /// - parameters:
   ///   - distinguishedName: specific DN
   ///   - attributes: attributes as an dictionary to modify
+  ///   - method: specify if an attribute should be added, removed or replaced (default)
+  ///       add:     LDAP_MOD_ADD | LDAP_MOD_BVALUES
+  ///       remove:  LDAP_MOD_DELETE | LDAP_MOD_BVALUES
+  ///       replace: LDAP_MOD_REPLACE | LDAP_MOD_BVALUES
   /// - throws:
   ///   - Exception with message, such as no permission, or object class violation, etc.
-  
-  public func modify(distinguishedName: String, attributes: [String:[String]]) throws {
+
+  public func modify(distinguishedName: String, attributes: [String:[String]], method: Int32 = LDAP_MOD_REPLACE | LDAP_MOD_BVALUES) throws {
 
     // map the keys to an array
     let keys:[String] = attributes.keys.map { $0 }
 
     // map the key array to a modification array
-    let mods:[LDAPMod] = keys.map { self.modAlloc(method: LDAP_MOD_REPLACE | LDAP_MOD_BVALUES, key: $0, values: attributes[$0]!)}
+    let mods:[LDAPMod] = keys.map { self.modAlloc(method: method, key: $0, values: attributes[$0]!)}
 
     // get the pointers
     let pMods = mods.asUnsafeNullTerminatedPointers()
@@ -787,12 +791,16 @@ public class LDAP {
   ///   - distinguishedName: specific DN
   ///   - attributes: attributes as an dictionary to modify
   ///   - completion: callback once done. If something wrong, an error message will pass to the closure.
+  ///   - method: specify if an attribute should be added, removed or replaced (default)
+  ///       add:     LDAP_MOD_ADD | LDAP_MOD_BVALUES
+  ///       remove:  LDAP_MOD_DELETE | LDAP_MOD_BVALUES
+  ///       replace: LDAP_MOD_REPLACE | LDAP_MOD_BVALUES
   
-  public func modify(distinguishedName: String, attributes: [String:[String]],completion: @escaping (String?)-> Void) {
+  public func modify(distinguishedName: String, attributes: [String:[String]],completion: @escaping (String?)-> Void, method: Int32 = LDAP_MOD_REPLACE | LDAP_MOD_BVALUES) {
     threading.async {
       do {
         // perform adding
-        try self.modify(distinguishedName: distinguishedName, attributes: attributes)
+        try self.modify(distinguishedName: distinguishedName, attributes: attributes, method)
 
         // if nothing wrong, callback
         completion(nil)


### PR DESCRIPTION
Implement option for "modify" method to add and remove attributes. Currently only replacements are possible.
This patch is required for example to add or delete a member from an AD group